### PR TITLE
Fix wrong Image URL on FFZ

### DIFF
--- a/Extension/content/Addons/FFZ/FFZChannel.js
+++ b/Extension/content/Addons/FFZ/FFZChannel.js
@@ -24,7 +24,7 @@ export default class FFZChannel{
             success: data => {
                 for (let emoteSet in data.sets) {
                     for (let emote of data.sets[emoteSet].emoticons) {
-                        this.emotes.push(new Emote(emote.name, emote.urls['1'], emote.width, emote.height));
+                        this.emotes.push(new Emote(emote.name, emote.urls['4'], emote.width, emote.height));
                     }
                 }
                 


### PR DESCRIPTION
Should fix the resizing issue with FFZ Emotes
(Changed that to the 4th URL so it should always grab the biggest image not the smallest)

fixes #12 